### PR TITLE
feat(core): add models setup and improve composables

### DIFF
--- a/packages/cli/src/templates/renderComposableForDef.ts
+++ b/packages/cli/src/templates/renderComposableForDef.ts
@@ -3,7 +3,5 @@ type ComposableForDefTemplateData = {
 };
 
 export default function renderComposableForDef({ composable }: ComposableForDefTemplateData) {
-  return `
-...${composable}
-`.trim();
+  return composable;
 }

--- a/packages/core/src/model/checks/isComposable.ts
+++ b/packages/core/src/model/checks/isComposable.ts
@@ -1,0 +1,9 @@
+import { ModelComposable } from '@foscia/core/model/types';
+import { SYMBOL_MODEL_COMPOSABLE } from '@foscia/core/symbols';
+import { isFosciaType } from '@foscia/shared';
+
+export default function isComposable(
+  value: unknown,
+): value is ModelComposable<any> {
+  return isFosciaType(value, SYMBOL_MODEL_COMPOSABLE);
+}

--- a/packages/core/src/model/makeComposable.ts
+++ b/packages/core/src/model/makeComposable.ts
@@ -1,13 +1,27 @@
 import makeDefinition from '@foscia/core/model/makeDefinition';
-import { ModelInstance, ModelParsedDefinition } from '@foscia/core/model/types';
+import makeModelSetup from '@foscia/core/model/makeModelSetup';
+import {
+  ModelComposable,
+  ModelFlattenDefinition,
+  ModelInstance,
+  ModelParsedDefinition,
+  ModelRawSetup,
+} from '@foscia/core/model/types';
+import { SYMBOL_MODEL_COMPOSABLE } from '@foscia/core/symbols';
 
 /**
  * Create a composable definition which will be used by a model factory.
  *
  * @param rawDefinition
+ * @param rawSetup
  */
 export default function makeComposable<D extends {} = {}>(
-  rawDefinition?: D & ThisType<ModelInstance<ModelParsedDefinition<D>>>,
+  rawDefinition?: D & ThisType<ModelInstance<ModelFlattenDefinition<D>>>,
+  rawSetup?: ModelRawSetup<D>,
 ) {
-  return makeDefinition(rawDefinition) as ModelParsedDefinition<D>;
+  return {
+    $FOSCIA_TYPE: SYMBOL_MODEL_COMPOSABLE,
+    $definition: makeDefinition(rawDefinition),
+    $setup: makeModelSetup(rawSetup),
+  } as ModelComposable<ModelParsedDefinition<D>>;
 }

--- a/packages/core/src/model/makeDefinition.ts
+++ b/packages/core/src/model/makeDefinition.ts
@@ -1,3 +1,4 @@
+import isComposable from '@foscia/core/model/checks/isComposable';
 import isPendingPropDef from '@foscia/core/model/checks/isPendingPropDef';
 import isPropDef from '@foscia/core/model/checks/isPropDef';
 import { ModelParsedDefinition } from '@foscia/core/model/types';
@@ -5,6 +6,10 @@ import { Dictionary, eachDescriptors, makeDescriptorHolder } from '@foscia/share
 
 function parseDescriptor(key: string, descriptor: PropertyDescriptor) {
   if (descriptor.value) {
+    if (isComposable(descriptor.value)) {
+      return descriptor.value;
+    }
+
     if (isPropDef(descriptor.value)) {
       return { ...descriptor.value, key };
     }

--- a/packages/core/src/model/makeModelFactory.ts
+++ b/packages/core/src/model/makeModelFactory.ts
@@ -1,19 +1,30 @@
 import makeModelClass from '@foscia/core/model/makeModelClass';
+import makeModelSetup from '@foscia/core/model/makeModelSetup';
 import {
   ExtendableModel,
   ModelConfig,
+  ModelFlattenDefinition,
   ModelInstance,
   ModelParsedDefinition,
+  ModelRawSetup,
 } from '@foscia/core/model/types';
 
 export default function makeModelFactory<ND extends {} = {}>(
   baseConfig?: ModelConfig,
-  baseRawDefinition?: ND & ThisType<ModelInstance<ModelParsedDefinition<ND>>>,
+  // eslint-disable-next-line max-len
+  baseRawDefinition?: ND & ThisType<ModelInstance<ModelFlattenDefinition<ModelParsedDefinition<ND>>>>,
+  baseRawSetup?: ModelRawSetup<ModelFlattenDefinition<ModelParsedDefinition<ND>>>,
 ) {
+  const baseSetup = makeModelSetup(baseRawSetup);
+
   return <D extends {} = {}>(
     rawConfig: string | (ModelConfig & { type: string; }),
-    rawDefinition?: D & ThisType<ModelInstance<ModelParsedDefinition<ND & D>>>,
+    // eslint-disable-next-line max-len
+    rawDefinition?: D & ThisType<ModelInstance<ModelFlattenDefinition<ModelParsedDefinition<ND & D>>>>,
+    rawSetup?: ModelRawSetup<ModelFlattenDefinition<ModelParsedDefinition<ND & D>>>,
   ) => {
+    const setup = makeModelSetup(rawSetup);
+
     const { type, ...config } = typeof rawConfig === 'string'
       ? { type: rawConfig }
       : rawConfig;
@@ -21,10 +32,13 @@ export default function makeModelFactory<ND extends {} = {}>(
     return makeModelClass(type, {
       ...baseConfig,
       ...config,
+    }, {
+      boot: [...baseSetup.boot, ...setup.boot],
+      init: [...baseSetup.init, ...setup.init],
     }).extend({
       ...baseRawDefinition,
       ...rawDefinition,
       // eslint-disable-next-line max-len
-    }) as ExtendableModel<ModelParsedDefinition<ND & D>, ModelInstance<ModelParsedDefinition<ND & D>>>;
+    }) as ExtendableModel<ModelFlattenDefinition<ModelParsedDefinition<ND & D>>, ModelInstance<ModelFlattenDefinition<ModelParsedDefinition<ND & D>>>>;
   };
 }

--- a/packages/core/src/model/makeModelSetup.ts
+++ b/packages/core/src/model/makeModelSetup.ts
@@ -1,0 +1,9 @@
+import { ModelRawSetup, ModelSetup } from '@foscia/core/model/types';
+import { wrap } from '@foscia/shared';
+
+export default function makeModelSetup<D extends {} = {}>(rawSetup?: ModelRawSetup<D>) {
+  return {
+    boot: [...wrap(rawSetup?.boot)],
+    init: [...wrap(rawSetup?.init)],
+  } as ModelSetup<D>;
+}

--- a/packages/core/src/model/types.ts
+++ b/packages/core/src/model/types.ts
@@ -1,6 +1,7 @@
 import { Hookable, HookCallback, SyncHookCallback } from '@foscia/core/hooks/types';
 import {
   SYMBOL_MODEL_CLASS,
+  SYMBOL_MODEL_COMPOSABLE,
   SYMBOL_MODEL_INSTANCE,
   SYMBOL_MODEL_PROP_ATTRIBUTE,
   SYMBOL_MODEL_PROP_ID,
@@ -11,14 +12,17 @@ import {
 } from '@foscia/core/symbols';
 import { ObjectTransformer } from '@foscia/core/transformers/types';
 import {
+  Arrayable,
   Awaitable,
   Constructor,
   DescriptorHolder,
   Dictionary,
   FosciaObject,
+  OmitNever,
   Optional,
   Prev,
   Transformer,
+  UnionToIntersection,
 } from '@foscia/shared';
 
 /**
@@ -37,6 +41,42 @@ export type ModelConfig = {
   cloneValue?: <T>(value: T) => T;
   [K: string]: any;
 };
+
+/**
+ * Callback run after the model factory tasks (definition parsing, etc.).
+ */
+export type ModelBootCallback<D extends {}> = (model: Model<D, ModelInstance<D>>) => void;
+
+/**
+ * Callback run after the model constructor tasks (properties setup, etc.).
+ */
+export type ModelInitCallback<D extends {}> = (instance: ModelInstance<D>) => void;
+
+/**
+ * Raw model setup configuration.
+ */
+export type ModelRawSetup<D extends {} = any> = {
+  boot?: Arrayable<ModelBootCallback<D>>;
+  init?: Arrayable<ModelInitCallback<D>>;
+};
+
+/**
+ * Parsed model setup configuration.
+ */
+export type ModelSetup<D extends {} = any> = {
+  boot: ModelBootCallback<D>[];
+  init: ModelInitCallback<D>[];
+};
+
+/**
+ * Model composable definition which can be included on any models.
+ */
+export type ModelComposable<D extends {}> =
+  & {
+    $definition: D;
+    $setup: ModelSetup<D>;
+  }
+  & FosciaObject<typeof SYMBOL_MODEL_COMPOSABLE>;
 
 /**
  * Model instance ID default typing.
@@ -162,17 +202,30 @@ export type ModelParsedDefinitionProp<K, V> =
   V extends RawModelAttribute<any, any> ? V & ModelPropNormalized<K>
     : V extends RawModelRelation<any, any> ? V & ModelPropNormalized<K>
       : V extends RawModelId<any, any> ? V & ModelPropNormalized<K>
-        : V extends DescriptorHolder<any> ? V
-          : DescriptorHolder<V>;
+        : V extends ModelComposable<any> ? never
+          : V extends DescriptorHolder<any> ? V
+            : DescriptorHolder<V>;
 
 /**
- * The parsed model definition with non attributes/relations properties'
- * descriptors wrapped in holders.
+ * The parsed model definition with non composables/attributes/relations
+ * properties' descriptors wrapped in holders.
  */
 export type ModelParsedDefinition<D extends {} = {}> = {
-  [K in keyof D]: D[K] extends PendingModelProp<RawModelProp<any, any>>
-    ? ModelParsedDefinitionProp<K, D[K]['definition']> : ModelParsedDefinitionProp<K, D[K]>;
+  [K in keyof D]: D[K] extends ModelComposable<any>
+    ? D[K] : D[K] extends PendingModelProp<RawModelProp<any, any>>
+      ? ModelParsedDefinitionProp<K, D[K]['definition']> : ModelParsedDefinitionProp<K, D[K]>;
 };
+
+/**
+ * The flatten and parsed model definition with composables properties
+ * flattened to the definition root.
+ */
+export type ModelFlattenDefinition<D extends {}> =
+  & UnionToIntersection<{} | {
+    [K in keyof D]: D[K] extends ModelComposable<infer CD>
+      ? ModelFlattenDefinition<CD> : never;
+  }[keyof D]>
+  & OmitNever<{ [K in keyof D]: D[K] extends ModelComposable<any> ? never : D[K] }>;
 
 /**
  * Extract model's IDs, attributes and relations from the whole definition.
@@ -274,8 +327,10 @@ export type ExtendableModel<D extends {} = any, I extends ModelInstance<D> = any
   & {
     configure(config?: ModelConfig, override?: boolean): ExtendableModel<D, ModelInstance<D>>;
     extend<ND extends {} = {}>(
-      rawDefinition?: ND & ThisType<ModelInstance<D & ModelParsedDefinition<ND>>>,
-    ): ExtendableModel<D & ModelParsedDefinition<ND>, ModelInstance<D & ModelParsedDefinition<ND>>>;
+      // eslint-disable-next-line max-len
+      rawDefinition?: ND & ThisType<ModelInstance<ModelFlattenDefinition<D & ModelParsedDefinition<ND>>>>,
+      // eslint-disable-next-line max-len
+    ): ExtendableModel<ModelFlattenDefinition<D & ModelParsedDefinition<ND>>, ModelInstance<ModelFlattenDefinition<D & ModelParsedDefinition<ND>>>>;
   }
   & Model<D, I>;
 

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -6,3 +6,4 @@ export const SYMBOL_MODEL_RELATION_HAS_ONE: unique symbol = Symbol('foscia: mode
 export const SYMBOL_MODEL_RELATION_HAS_MANY: unique symbol = Symbol('foscia: model relation has many');
 export const SYMBOL_MODEL_CLASS: unique symbol = Symbol('foscia: model class');
 export const SYMBOL_MODEL_INSTANCE: unique symbol = Symbol('foscia: model instance');
+export const SYMBOL_MODEL_COMPOSABLE: unique symbol = Symbol('foscia: model composable');

--- a/packages/core/tests/mocks/models/post.mock.ts
+++ b/packages/core/tests/mocks/models/post.mock.ts
@@ -2,7 +2,7 @@ import { attr, makeModel, toDateTime } from '@foscia/core';
 import commentable from '../composables/commentable';
 
 export default class PostMock extends makeModel('posts', {
-  ...commentable,
+  commentable,
   title: attr<string>(),
   body: attr<string | null>(),
   publishedAt: attr(toDateTime()).nullable().readOnly(),

--- a/packages/rest/tests/mocks/composables/commentable.ts
+++ b/packages/rest/tests/mocks/composables/commentable.ts
@@ -1,0 +1,6 @@
+import { hasMany, makeComposable } from '@foscia/core';
+import CommentMock from '../models/comment.mock';
+
+export default makeComposable({
+  comments: hasMany(() => CommentMock),
+});

--- a/packages/rest/tests/mocks/models/post.mock.ts
+++ b/packages/rest/tests/mocks/models/post.mock.ts
@@ -1,10 +1,10 @@
-import { attr, hasMany, makeModel, toDateTime } from '@foscia/core';
-import CommentMock from './comment.mock';
+import { attr, makeModel, toDateTime } from '@foscia/core';
+import commentable from '../composables/commentable';
 
 export default class PostMock extends makeModel('posts', {
+  commentable,
   title: attr<string>(),
   body: attr<string | null>(),
-  comments: hasMany(() => CommentMock),
   publishedAt: attr(toDateTime()).nullable().readOnly(),
 }) {
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -22,6 +22,13 @@ export type OnlyFalsy<T> = T extends Falsy ? T : never;
 
 export type Transformer<T, U = T> = (value: T) => U;
 
+export type OmitNever<T> = {
+  [K in keyof T as T[K] extends never ? never : K]: T[K]
+};
+
+export type UnionToIntersection<U> =
+  (U extends any ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
 export type IdentifiersMap<Type, Id, T> = {
   find: (type: Type, id: Id) => T | null;
   put: (type: Type, id: Id, value: T) => void;


### PR DESCRIPTION
New model setup tasks and composable as dedicated objects.

BREAKING CHANGE: composable are now dedicated objects and should not be object-spread in your definition anymore. Instead of doing `{ ...publishable }` you must use `{ publishable }`.